### PR TITLE
Audit fixes: cross-platform parity, preset tuning, tests + CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  python:
+    name: pytest + ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      # Dev/CI-only tools; the scripts themselves stay stdlib-only.
+      - run: pip install pytest ruff
+      - run: ruff check .
+      - run: pytest -q
+
+  powershell:
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint SlimBrave.ps1
+        shell: pwsh
+        run: |
+          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+          $results = Invoke-ScriptAnalyzer -Path ./SlimBrave.ps1 -Severity Warning, Error
+          $results | Format-Table -AutoSize | Out-String | Write-Host
+          # Warnings are informational; only hard errors fail the build.
+          if ($results | Where-Object Severity -eq 'Error') { exit 1 }

--- a/Presets/Balanced Privacy Preset.json
+++ b/Presets/Balanced Privacy Preset.json
@@ -15,7 +15,6 @@
         "WebRtcIPHandling": "disable_non_proxied_udp",
         "QuicAllowed": false,
         "BlockThirdPartyCookies": true,
-        "ForceGoogleSafeSearch": true,
         "BraveRewardsDisabled": true,
         "BraveWalletDisabled": true,
         "BraveVPNDisabled": true,

--- a/Presets/Maximum Privacy Preset.json
+++ b/Presets/Maximum Privacy Preset.json
@@ -18,7 +18,6 @@
         "WebRtcIPHandling": "disable_non_proxied_udp",
         "QuicAllowed": false,
         "BlockThirdPartyCookies": true,
-        "ForceGoogleSafeSearch": true,
         "BraveRewardsDisabled": true,
         "BraveWalletDisabled": true,
         "BraveVPNDisabled": true,
@@ -46,6 +45,5 @@
         "DefaultBrowserSettingEnabled": false,
         "DeveloperToolsAvailability": 2,
         "BraveWaybackMachineEnabled": false
-    },
-    "DnsMode": "off"
+    }
 }

--- a/Presets/Performance Focused Preset.json
+++ b/Presets/Performance Focused Preset.json
@@ -1,6 +1,8 @@
 {
     "Features": {
         "MetricsReportingEnabled": false,
+        "BraveP3AEnabled": false,
+        "BraveStatsPingEnabled": false,
         "BraveDeAmpEnabled": true,
         "BraveDebouncingEnabled": true,
         "BraveTrackingQueryParametersFilteringEnabled": true,

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Pin Brave's own protection defaults as managed policy so they can't be weakened 
 | `--reset` | Remove the managed policy file |
 | `--policy-file PATH` | Override policy file path |
 | `--doh-templates URL` | Set custom DNS-over-HTTPS template URL |
-| `--channels LIST` | Comma-separated channels to target (`stable,beta,nightly`). Default `auto` = all detected. macOS writes one plist per channel; Linux always shares a single policy file. |
+| `--channels LIST` | Comma-separated channels to target (`stable,beta,nightly`; Linux also accepts `dev`). Default `auto` = all detected. macOS writes one plist per channel; Linux always shares a single policy file. |
 | `--persist MODE` | macOS persistence: `off` (plist only; may reset after reboot on macOS 13+) or `on` (install an Apple Configuration Profile via System Settings; durable, Apple-recommended). Omitted = reuse whatever mode is currently installed; falls back to `off` if nothing is. Linux ignores this flag — its `/etc/brave/policies` file is already durable. |
 | `-h`, `--help` | Show help |
 
@@ -214,7 +214,7 @@ Import/export uses the same JSON format as the Windows PowerShell version. Confi
 - **Brave Features:** Kills Rewards, Wallet, VPN, AI Chat, Tor, Sync, and Email Aliases.
 - **Shields:** Pins ad blocking, fingerprinting protection, strict HTTPS, capped referrers, and forget-on-close storage as managed policy.
 - **Performance:** Disables background processes, recommendations, and bloat.
-- **DNS:** Uses plain DNS (no HTTPS) to prevent potential logging by DoH providers.
+- **DNS:** Left unmanaged. Forcing DoH off would hand every DNS query to your ISP in cleartext, while forcing DoH on concentrates that visibility at the DoH provider — which trade-off is right depends on who you distrust more, so the preset leaves the choice to you (set it manually in the DNS section if you have a preference).
 - **Note:** No longer forces incognito-only browsing (earlier versions set `IncognitoModeAvailability: 2`, which silently disabled history, persistent logins, and most extensions). Forget-on-close storage covers the privacy goal; the Force Incognito toggle is still available manually.
 - **Best for:** Paranoid users, journalists, activists, or anyone who wants Brave as private as possible.
 
@@ -227,7 +227,7 @@ Import/export uses the same JSON format as the Windows PowerShell version. Confi
 - **Best for:** Most users who want privacy but still need convenience features.
 
 ### Performance Focused Preset
-- **Telemetry:** Only blocks metrics and feedback surveys (keeps some safe browsing).
+- **Telemetry:** Blocks metrics reporting, P3A analytics, and the daily stats ping (Safe Browsing stays untouched).
 - **Brave Features:** Disables Rewards, Wallet, VPN, and AI to declutter the browser.
 - **Performance:** Kills background processes, shopping features, and promotions.
 - **DNS:** Automatic DoH for a balance of speed and security.

--- a/SlimBrave.ps1
+++ b/SlimBrave.ps1
@@ -14,10 +14,6 @@ $machineRegistryPath = "HKLM:\SOFTWARE\Policies\BraveSoftware\Brave"
 $userRegistryPath   = "HKCU:\SOFTWARE\Policies\BraveSoftware\Brave"
 $registryPath       = $machineRegistryPath
 
-if (-not (Test-Path -Path $registryPath)) {
-    New-Item -Path $registryPath -Force | Out-Null
-}
-
 Clear-Host
 
 # ---------------------------------------------------------------------------
@@ -44,8 +40,13 @@ function Set-DnsSettings {
         }
         $resolvedMode = "secure"
         Set-ItemProperty -Path $regKey -Name "DnsOverHttpsTemplates" -Value $dnsTemplates -Type String -Force
+    } elseif ($dnsMode -eq "secure" -and -not [string]::IsNullOrWhiteSpace($dnsTemplates)) {
+        # "secure" keeps an explicit template when one is provided — parity
+        # with the Linux/macOS scripts, so cross-platform configs with
+        # DnsMode=secure + DnsTemplates don't lose their resolver here.
+        Set-ItemProperty -Path $regKey -Name "DnsOverHttpsTemplates" -Value $dnsTemplates -Type String -Force
     } else {
-        # Remove the templates key if not using custom
+        # Remove the templates key when no template applies
         if (Get-ItemProperty -Path $regKey -Name "DnsOverHttpsTemplates" -ErrorAction SilentlyContinue) {
             Remove-ItemProperty -Path $regKey -Name "DnsOverHttpsTemplates" -ErrorAction SilentlyContinue
         }
@@ -154,21 +155,26 @@ function Repair-BravePrefs {
     registry does NOT roll those entries back — the profile keeps the
     per-URL exceptions, so unchecking "Disable Brave Shields" leaves
     shields stuck off. The exceptions land in every profile that was used
-    while the policy was active (Default, Profile 1, Profile 2, ...), so
-    every profile directory is scrubbed, not just Default.
+    while the policy was active (Default, Profile 1, Profile 2, ...) and
+    in every installed channel (Stable, Beta, Nightly, Dev — the registry
+    policy applies to all of them), so every profile directory of every
+    channel is scrubbed, not just Stable's Default.
 
     Returns a hashtable @{ Removed = N; Running = $true/$false }.
     Safe to call when files or keys do not exist.
     #>
+    # Every Brave channel runs as brave.exe on Windows.
     $running = ($null -ne (Get-Process brave -ErrorAction SilentlyContinue))
-    $userData = Join-Path $env:LOCALAPPDATA "BraveSoftware\Brave-Browser\User Data"
-    if (-not (Test-Path $userData)) { return @{ Removed = 0; Running = $running } }
 
     $removed = 0
-    $profileDirs = Get-ChildItem -Path $userData -Directory -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -eq 'Default' -or $_.Name -like 'Profile *' }
-    foreach ($dir in $profileDirs) {
-        $removed += Repair-OneBravePrefs (Join-Path $dir.FullName 'Preferences')
+    foreach ($channelDir in @('Brave-Browser', 'Brave-Browser-Beta', 'Brave-Browser-Nightly', 'Brave-Browser-Dev')) {
+        $userData = Join-Path $env:LOCALAPPDATA "BraveSoftware\$channelDir\User Data"
+        if (-not (Test-Path $userData)) { continue }
+        $profileDirs = Get-ChildItem -Path $userData -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -eq 'Default' -or $_.Name -like 'Profile *' }
+        foreach ($dir in $profileDirs) {
+            $removed += Repair-OneBravePrefs (Join-Path $dir.FullName 'Preferences')
+        }
     }
 
     return @{ Removed = $removed; Running = $running }
@@ -710,7 +716,7 @@ $dnsDropdown.Size = New-Object System.Drawing.Size(150, 20)
 # "unmanaged" (the default) writes no DNS policy at all, leaving Brave's
 # DNS settings user-controlled. The other four are managed-policy values —
 # including "off", which actively force-disables DoH as policy.
-$dnsDropdown.Items.AddRange(@("unmanaged", "off", "automatic", "secure", "custom"))
+$dnsDropdown.Items.AddRange(@("unmanaged", "automatic", "off", "secure", "custom"))
 $dnsDropdown.FlatStyle = [System.Windows.Forms.FlatStyle]::Flat
 $dnsDropdown.BackColor = $theme.InputBack
 $dnsDropdown.ForeColor = $theme.InputText
@@ -739,10 +745,10 @@ $dnsTemplateBox.BackColor = $theme.InputBack
 $dnsTemplateBox.ForeColor = $theme.InputText
 $dnsTemplateBox.Enabled = $false
 $form.Controls.Add($dnsTemplateBox)
-$tooltip.SetToolTip($dnsTemplateBox, "DoH resolver template used with the 'custom' mode, e.g. https://cloudflare-dns.com/dns-query")
+$tooltip.SetToolTip($dnsTemplateBox, "DoH resolver template, e.g. https://cloudflare-dns.com/dns-query. Required for 'custom' mode, optional for 'secure'.")
 
 $dnsDropdown.Add_SelectedIndexChanged({
-    $dnsTemplateBox.Enabled = ($dnsDropdown.SelectedItem -eq "custom")
+    $dnsTemplateBox.Enabled = ($dnsDropdown.SelectedItem -in @("custom", "secure"))
 })
 
 # ---------------------------------------------------------------------------
@@ -800,6 +806,12 @@ $saveButton.Add_Click({
             [System.Windows.Forms.MessageBoxIcon]::Warning
         )
         return
+    }
+
+    # Created lazily here rather than at launch, so merely opening the app
+    # never writes to the registry.
+    if (-not (Test-Path -Path $registryPath)) {
+        New-Item -Path $registryPath -Force | Out-Null
     }
 
     # Build a hashtable of selected features keyed by policy key name.
@@ -906,7 +918,9 @@ function Reset-AllSettings {
 
     if ($confirm -eq "Yes") {
         try {
-            Remove-Item -Path $registryPath -Recurse -Force
+            if (Test-Path -Path $registryPath) {
+                Remove-Item -Path $registryPath -Recurse -Force
+            }
             if (Test-Path -Path $userRegistryPath) {
                 Remove-Item -Path $userRegistryPath -Recurse -Force
             }
@@ -1161,7 +1175,7 @@ function Initialize-CurrentSettings {
         $dnsDropdown.SelectedItem = "unmanaged"
     }
 
-    $dnsTemplateBox.Enabled = ($dnsDropdown.SelectedItem -eq "custom")
+    $dnsTemplateBox.Enabled = ($dnsDropdown.SelectedItem -in @("custom", "secure"))
 }
 
 Initialize-CurrentSettings

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+# Dev/CI-only lint config — the scripts themselves have no dependencies.
+# Ruff's default rule set (pyflakes + a pycodestyle core) is used as-is;
+# line length is not enforced (the feature tables read better wide).
+target-version = "py38"

--- a/slimbrave-linux.py
+++ b/slimbrave-linux.py
@@ -62,10 +62,24 @@ def _user_home_for_brave():
     sudo_user = os.environ.get("SUDO_USER") or os.environ.get("USER")
     if not sudo_user or sudo_user == "root":
         return None
-    try:
-        return os.path.expanduser(f"~{sudo_user}")
-    except KeyError:
+    home = os.path.expanduser(f"~{sudo_user}")
+    # expanduser returns the input unchanged when the user is unknown
+    if home.startswith("~"):
         return None
+    return home
+
+
+def _chown_to_sudo_user(path):
+    """Return a root-created file to the invoking user (no-op without sudo)."""
+    sudo_user = os.environ.get("SUDO_USER")
+    if not sudo_user:
+        return
+    try:
+        import pwd
+        user_info = pwd.getpwnam(sudo_user)
+        os.chown(path, user_info.pw_uid, user_info.pw_gid)
+    except (ImportError, KeyError, OSError):
+        pass
 
 
 def _channel_prefs_path(user_data_dir):
@@ -75,6 +89,24 @@ def _channel_prefs_path(user_data_dir):
         return None
     return os.path.join(
         home, ".config", "BraveSoftware", user_data_dir, "Default", "Preferences",
+    )
+
+
+def _flatpak_prefs_path():
+    """Return the Flatpak Brave's Default profile Preferences path.
+
+    Flatpak keeps the profile under ~/.var/app/com.brave.Browser/config
+    instead of ~/.config, so the native channel paths never see it. The
+    Flathub manifest grants --filesystem=host-etc specifically to load
+    policies from /etc/brave/policies, so the shared POLICY_FILE works;
+    only prefs repair needs this extra location.
+    """
+    home = _user_home_for_brave()
+    if not home:
+        return None
+    return os.path.join(
+        home, ".var", "app", "com.brave.Browser", "config",
+        "BraveSoftware", "Brave-Browser", "Default", "Preferences",
     )
 
 
@@ -234,6 +266,22 @@ def detect_brave():
             ))
             detected_labels.append(ch["label"])
 
+    # Flatpak keeps its profile under ~/.var/app, so the loop above cannot
+    # see it. Add a synthetic stable-channel record pointing at the Flatpak
+    # prefs so leak repair covers that profile too. Channel id stays
+    # "stable" so --channels filtering keeps working.
+    flatpak_prefs = _flatpak_prefs_path()
+    if flatpak_prefs and os.path.isdir(
+            os.path.dirname(os.path.dirname(flatpak_prefs))):
+        installations.append(_make_installation(
+            {"id": "stable", "label": "Stable (Flatpak)",
+             "user_data_dir": "Brave-Browser", "process_name": "brave"},
+            app_path="com.brave.Browser" if method == "flatpak" else "",
+            plist_path=POLICY_FILE,
+            prefs_path=flatpak_prefs,
+        ))
+        detected_labels.append("Flatpak")
+
     if not installations:
         stable = LINUX_CHANNELS[0]
         installations.append(_make_installation(
@@ -358,7 +406,6 @@ ROW_HEADER = 0
 ROW_FEATURE = 1
 ROW_DNS = 2
 ROW_DNS_TEMPLATE = 3
-ROW_CHANNEL = 4
 
 
 def build_rows(installations=None):
@@ -367,7 +414,7 @@ def build_rows(installations=None):
     On Linux every channel shares POLICY_FILE so a per-channel selector
     cannot meaningfully scope the policy write. The `installations`
     argument is accepted for API parity with the macOS script but does
-    not produce ROW_CHANNEL rows here.
+    not affect the layout.
     """
     rows = []
     for cat in CATEGORIES:
@@ -530,14 +577,9 @@ def _repair_one_prefs(pref_path):
     except OSError:
         return 0
 
-    sudo_user = os.environ.get("SUDO_USER")
-    if sudo_user:
-        try:
-            import pwd
-            user_info = pwd.getpwnam(sudo_user)
-            os.chown(pref_path, user_info.pw_uid, user_info.pw_gid)
-        except (ImportError, KeyError, OSError):
-            pass
+    # We're root via sudo — return the file to its original owner so the
+    # user's Brave can rewrite it on the next session.
+    _chown_to_sudo_user(pref_path)
 
     return removed
 
@@ -643,8 +685,8 @@ def _write_one_policy(plist_path, policy):
     return True, ""
 
 
-def _selected_channel_targets(installations, rows):
-    """Linux UI does not expose channel rows, so every installation is targeted."""
+def _selected_channel_targets(installations):
+    """Linux has no per-channel scoping, so every installation is targeted."""
     return list(installations)
 
 
@@ -672,7 +714,7 @@ def apply_policy(rows, installations=None):
     if installations is None:
         targets = [(POLICY_FILE, "")]
     else:
-        targets = _dedupe_plist_targets(_selected_channel_targets(installations, rows))
+        targets = _dedupe_plist_targets(_selected_channel_targets(installations))
 
     if not targets:
         return False, "No Brave channel selected."
@@ -687,7 +729,7 @@ def apply_policy(rows, installations=None):
             written_labels.append(label)
 
     repair_targets = (
-        _selected_channel_targets(installations, rows)
+        _selected_channel_targets(installations)
         if installations else None
     )
     return True, _post_apply_message(
@@ -714,7 +756,7 @@ def reset_policy(rows, installations=None):
     if installations is None:
         targets = [(POLICY_FILE, "")]
     else:
-        targets = _dedupe_plist_targets(_selected_channel_targets(installations, rows))
+        targets = _dedupe_plist_targets(_selected_channel_targets(installations))
 
     if not targets:
         return False, "No Brave channel selected."
@@ -739,7 +781,7 @@ def reset_policy(rows, installations=None):
         return False, f"Failed to reset: {e}"
 
     repair_targets = (
-        _selected_channel_targets(installations, rows)
+        _selected_channel_targets(installations)
         if installations else None
     )
     repaired, running = repair_brave_prefs(repair_targets)
@@ -809,6 +851,9 @@ def export_settings(rows, path):
         if out_dir:
             os.makedirs(out_dir, exist_ok=True)
         _atomic_write(path, json.dumps(settings, indent=4))
+        # Running as root: hand the export back to the invoking user so it
+        # isn't a root-owned file stranded in their home directory.
+        _chown_to_sudo_user(path)
         return True, f"Exported to {path}"
     except OSError as e:
         return False, f"Export failed: {e}"
@@ -910,7 +955,7 @@ def init_colors():
 def selectable_indices(rows):
     """Return list of row indices that can receive cursor focus."""
     return [i for i, r in enumerate(rows)
-            if r["type"] in (ROW_FEATURE, ROW_DNS, ROW_DNS_TEMPLATE, ROW_CHANNEL)]
+            if r["type"] in (ROW_FEATURE, ROW_DNS, ROW_DNS_TEMPLATE)]
 
 
 def draw(stdscr, rows, cursor_idx, scroll_offset, focus, btn_idx,
@@ -973,13 +1018,6 @@ def draw(stdscr, rows, cursor_idx, scroll_offset, focus, btn_idx,
                 attr = curses.color_pair(CP_CHECKED)
             else:
                 attr = curses.color_pair(CP_NORMAL)
-        elif row["type"] == ROW_CHANNEL:
-            mark = "x" if row["checked"] else " "
-            line = f"    [{mark}] {row['text']}"
-            attr = (
-                curses.color_pair(CP_CHECKED) if row["checked"]
-                else curses.color_pair(CP_NORMAL)
-            )
         elif row["type"] == ROW_DNS:
             current = row["options"][row["selected"]]
             line = f"    < {current} >"
@@ -1280,9 +1318,6 @@ def main(stdscr, override_installations=None):
                 if row["type"] == ROW_FEATURE:
                     toggle_feature_row(rows, row)
                     status_msg = ""
-                elif row["type"] == ROW_CHANNEL:
-                    row["checked"] = not row["checked"]
-                    status_msg = ""
                 elif row["type"] == ROW_DNS:
                     row["selected"] = (row["selected"] + 1) % len(row["options"])
                     status_msg = ""
@@ -1345,9 +1380,6 @@ def main(stdscr, override_installations=None):
             elif focus == FOCUS_LIST:
                 if row["type"] == ROW_FEATURE:
                     toggle_feature_row(rows, row)
-                    status_msg = ""
-                elif row["type"] == ROW_CHANNEL:
-                    row["checked"] = not row["checked"]
                     status_msg = ""
                 elif row["type"] == ROW_DNS:
                     row["selected"] = (row["selected"] + 1) % len(row["options"])
@@ -1546,14 +1578,16 @@ if __name__ == "__main__":
             for w in brave_info["warnings"]:
                 print(f"Warning: {w}", file=sys.stderr)
 
+        # Accumulate so a later success cannot mask an earlier failure
+        # (e.g. --reset failing followed by a clean --import).
         rc = 0
         if args.reset:
-            rc = cli_reset(installations)
+            rc = max(rc, cli_reset(installations))
         if args.import_path:
-            rc = cli_import(args.import_path, installations,
-                            doh_templates=args.doh_templates or "")
+            rc = max(rc, cli_import(args.import_path, installations,
+                                    doh_templates=args.doh_templates or ""))
         if args.export_path:
-            rc = cli_export(args.export_path, installations)
+            rc = max(rc, cli_export(args.export_path, installations))
         sys.exit(rc)
 
     try:

--- a/slimbrave-mac.py
+++ b/slimbrave-mac.py
@@ -122,10 +122,24 @@ def _user_home_for_brave():
     sudo_user = os.environ.get("SUDO_USER") or os.environ.get("USER")
     if not sudo_user or sudo_user == "root":
         return None
-    try:
-        return os.path.expanduser(f"~{sudo_user}")
-    except KeyError:
+    home = os.path.expanduser(f"~{sudo_user}")
+    # expanduser returns the input unchanged when the user is unknown
+    if home.startswith("~"):
         return None
+    return home
+
+
+def _chown_to_sudo_user(path):
+    """Return a root-created file to the invoking user (no-op without sudo)."""
+    sudo_user = os.environ.get("SUDO_USER")
+    if not sudo_user:
+        return
+    try:
+        import pwd
+        user_info = pwd.getpwnam(sudo_user)
+        os.chown(path, user_info.pw_uid, user_info.pw_gid)
+    except (ImportError, KeyError, OSError):
+        pass
 
 
 def _mac_app_search_paths(app_name):
@@ -151,6 +165,24 @@ def _channel_prefs_path(user_data_dir):
         )
     return os.path.join(
         home, ".config", "BraveSoftware", user_data_dir, "Default", "Preferences",
+    )
+
+
+def _flatpak_prefs_path():
+    """Return the Flatpak Brave's Default profile Preferences path (Linux).
+
+    Flatpak keeps the profile under ~/.var/app/com.brave.Browser/config
+    instead of ~/.config, so the native channel paths never see it. The
+    Flathub manifest grants --filesystem=host-etc specifically to load
+    policies from /etc/brave/policies, so the shared POLICY_FILE works;
+    only prefs repair needs this extra location.
+    """
+    home = _user_home_for_brave()
+    if not home:
+        return None
+    return os.path.join(
+        home, ".var", "app", "com.brave.Browser", "config",
+        "BraveSoftware", "Brave-Browser", "Default", "Preferences",
     )
 
 
@@ -362,6 +394,22 @@ def detect_brave():
                 prefs_path=_channel_prefs_path(ch["user_data_dir"]),
             ))
             detected_labels.append(ch["label"])
+
+    # Flatpak keeps its profile under ~/.var/app, so the loop above cannot
+    # see it. Add a synthetic stable-channel record pointing at the Flatpak
+    # prefs so leak repair covers that profile too. Channel id stays
+    # "stable" so --channels filtering keeps working.
+    flatpak_prefs = _flatpak_prefs_path()
+    if flatpak_prefs and os.path.isdir(
+            os.path.dirname(os.path.dirname(flatpak_prefs))):
+        installations.append(_make_installation(
+            {"id": "stable", "label": "Stable (Flatpak)",
+             "user_data_dir": "Brave-Browser", "process_name": "brave"},
+            app_path="com.brave.Browser" if method == "flatpak" else "",
+            plist_path=POLICY_FILE,
+            prefs_path=flatpak_prefs,
+        ))
+        detected_labels.append("Flatpak")
 
     if not installations:
         # Nothing detected per-channel — fall back to a single stable record so
@@ -684,14 +732,7 @@ def _repair_one_prefs(pref_path):
 
     # We're root via sudo — return the file to its original owner so the
     # user's Brave can rewrite it on the next session.
-    sudo_user = os.environ.get("SUDO_USER")
-    if sudo_user:
-        try:
-            import pwd
-            user_info = pwd.getpwnam(sudo_user)
-            os.chown(pref_path, user_info.pw_uid, user_info.pw_gid)
-        except (ImportError, KeyError, OSError):
-            pass
+    _chown_to_sudo_user(pref_path)
 
     return removed
 
@@ -910,16 +951,22 @@ def _flush_cfprefsd():
 
 
 def _clear_persistence_artifacts():
-    """Remove any installed Configuration Profile.
+    """Remove any installed Configuration Profile and its mobileconfig.
 
     Called by reset and by apply when switching modes (so an `off` Apply
     after a previous `on` Apply cleanly tears the profile down). Plist
     file deletion is the caller's responsibility — apply/reset already
-    iterate over plist_path targets.
+    iterate over plist_path targets. The staged mobileconfig in /tmp is
+    removed too so a reset leaves nothing behind; a persist=on Apply
+    rewrites it immediately afterwards.
     """
     if not IS_MAC:
         return
     _remove_profile()
+    try:
+        os.remove(PERSIST_PROFILE_FILE)
+    except OSError:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -1102,7 +1149,7 @@ def apply_policy(rows, installations=None, persist_mode=PERSIST_DEFAULT,
         for plist_path, label in targets:
             try:
                 os.remove(plist_path)
-            except (FileNotFoundError, OSError):
+            except OSError:
                 pass
             bundle = _bundle_id_for_plist(plist_path)
             if bundle:
@@ -1306,6 +1353,9 @@ def export_settings(rows, path):
         if out_dir:
             os.makedirs(out_dir, exist_ok=True)
         _atomic_write(path, json.dumps(settings, indent=4))
+        # Running as root: hand the export back to the invoking user so it
+        # isn't a root-owned file stranded in their home directory.
+        _chown_to_sudo_user(path)
         return True, f"Exported to {path}"
     except OSError as e:
         return False, f"Export failed: {e}"
@@ -2296,15 +2346,17 @@ if __name__ == "__main__":
         if persist_mode is None:
             persist_mode = detect_persist_mode() if IS_MAC else PERSIST_DEFAULT
 
+        # Accumulate so a later success cannot mask an earlier failure
+        # (e.g. --reset failing followed by a clean --import).
         rc = 0
         if args.reset:
-            rc = cli_reset(installations)
+            rc = max(rc, cli_reset(installations))
         if args.import_path:
-            rc = cli_import(args.import_path, installations,
-                            doh_templates=args.doh_templates or "",
-                            persist_mode=persist_mode)
+            rc = max(rc, cli_import(args.import_path, installations,
+                                    doh_templates=args.doh_templates or "",
+                                    persist_mode=persist_mode))
         if args.export_path:
-            rc = cli_export(args.export_path, installations)
+            rc = max(rc, cli_export(args.export_path, installations))
         sys.exit(rc)
 
     # Interactive TUI mode

--- a/tests/test_slimbrave.py
+++ b/tests/test_slimbrave.py
@@ -1,0 +1,369 @@
+"""Unit tests for the pure logic shared by slimbrave-linux.py and slimbrave-mac.py.
+
+Both scripts are loaded as modules (their entry points are guarded by
+__main__) and every test runs against each, so a fix applied to one file
+that is missed in the other fails loudly here. Nothing in this file touches
+/etc, the registry, or a real Brave profile — filesystem work stays in
+pytest's tmp_path.
+"""
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load(alias, filename):
+    spec = importlib.util.spec_from_file_location(alias, ROOT / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULES = [
+    _load("slimbrave_linux", "slimbrave-linux.py"),
+    _load("slimbrave_mac", "slimbrave-mac.py"),
+]
+
+
+@pytest.fixture(params=MODULES, ids=["linux", "mac"])
+def mod(request):
+    return request.param
+
+
+def _check_feature(mod, rows, name):
+    """Check the feature row with the given display name (via toggle logic)."""
+    for row in rows:
+        if row["type"] == mod.ROW_FEATURE and row["text"] == name:
+            if not row["checked"]:
+                mod.toggle_feature_row(rows, row)
+            return row
+    raise AssertionError(f"feature not found: {name}")
+
+
+def _get_feature(mod, rows, name):
+    for row in rows:
+        if row["type"] == mod.ROW_FEATURE and row["text"] == name:
+            return row
+    raise AssertionError(f"feature not found: {name}")
+
+
+def _set_dns(mod, rows, mode, template=""):
+    for row in rows:
+        if row["type"] == mod.ROW_DNS:
+            row["selected"] = row["options"].index(mode)
+        elif row["type"] == mod.ROW_DNS_TEMPLATE:
+            row["value"] = template
+            row["cursor"] = len(template)
+
+
+def _checked_policy_pairs(mod, rows):
+    return {
+        row["key"]: row["value"]
+        for row in rows
+        if row["type"] == mod.ROW_FEATURE and row["checked"]
+    }
+
+
+# ---------------------------------------------------------------------------
+# _build_policy
+# ---------------------------------------------------------------------------
+
+
+def test_build_policy_collects_checked_features(mod):
+    rows = mod.build_rows()
+    _check_feature(mod, rows, "Disable Brave Rewards")
+    _check_feature(mod, rows, "Disable WebRTC IP Leak")
+    policy, err = mod._build_policy(rows)
+    assert err == ""
+    assert policy["BraveRewardsDisabled"] is True
+    assert policy["WebRtcIPHandling"] == "disable_non_proxied_udp"
+    assert "DnsOverHttpsMode" not in policy  # DNS defaults to unmanaged
+
+
+def test_build_policy_custom_dns_requires_template(mod):
+    rows = mod.build_rows()
+    _set_dns(mod, rows, "custom", "")
+    policy, err = mod._build_policy(rows)
+    assert policy is None
+    assert "template" in err.lower()
+
+
+def test_build_policy_custom_maps_to_secure_with_template(mod):
+    rows = mod.build_rows()
+    _set_dns(mod, rows, "custom", "https://dns.example/dns-query")
+    policy, err = mod._build_policy(rows)
+    assert err == ""
+    assert policy["DnsOverHttpsMode"] == "secure"
+    assert policy["DnsOverHttpsTemplates"] == "https://dns.example/dns-query"
+
+
+def test_build_policy_secure_keeps_optional_template(mod):
+    rows = mod.build_rows()
+    _set_dns(mod, rows, "secure", "https://dns.example/dns-query")
+    policy, _ = mod._build_policy(rows)
+    assert policy["DnsOverHttpsMode"] == "secure"
+    assert policy["DnsOverHttpsTemplates"] == "https://dns.example/dns-query"
+
+
+def test_build_policy_off_mode_writes_no_template(mod):
+    rows = mod.build_rows()
+    _set_dns(mod, rows, "off", "https://ignored.example/dns-query")
+    policy, _ = mod._build_policy(rows)
+    assert policy["DnsOverHttpsMode"] == "off"
+    assert "DnsOverHttpsTemplates" not in policy
+
+
+# ---------------------------------------------------------------------------
+# Group exclusivity
+# ---------------------------------------------------------------------------
+
+
+def test_toggle_feature_row_group_exclusivity(mod):
+    rows = mod.build_rows()
+    disable = _check_feature(mod, rows, "Disable Incognito Mode")
+    force = _check_feature(mod, rows, "Force Incognito Mode")
+    assert force["checked"] is True
+    assert disable["checked"] is False  # unchecked by the group rule
+
+
+def test_shields_group_exclusivity(mod):
+    rows = mod.build_rows()
+    off = _check_feature(mod, rows, "Disable Brave Shields")
+    on = _check_feature(mod, rows, "Force Shields On (All Sites)")
+    assert on["checked"] is True
+    assert off["checked"] is False
+
+
+# ---------------------------------------------------------------------------
+# Export / import round trip
+# ---------------------------------------------------------------------------
+
+
+def test_export_import_round_trip(mod, tmp_path):
+    rows = mod.build_rows()
+    _check_feature(mod, rows, "Force Incognito Mode")       # multi-value key, value 2
+    _check_feature(mod, rows, "Force Shields On (All Sites)")  # list value
+    _check_feature(mod, rows, "Disable Brave Rewards")
+    _set_dns(mod, rows, "custom", "https://dns.example/dns-query")
+    expected = _checked_policy_pairs(mod, rows)
+
+    out = tmp_path / "export.json"
+    ok, _ = mod.export_settings(rows, str(out))
+    assert ok
+
+    fresh = mod.build_rows()
+    ok, _ = mod.import_settings(fresh, str(out))
+    assert ok
+    assert _checked_policy_pairs(mod, fresh) == expected
+    assert mod.get_dns_mode(fresh) == "custom"
+    assert mod.get_dns_template(fresh) == "https://dns.example/dns-query"
+    # The multi-value key restored the *right* row
+    assert _get_feature(mod, fresh, "Force Incognito Mode")["checked"] is True
+    assert _get_feature(mod, fresh, "Disable Incognito Mode")["checked"] is False
+
+
+def test_export_omits_dns_when_unmanaged(mod, tmp_path):
+    rows = mod.build_rows()
+    _check_feature(mod, rows, "Disable Brave Rewards")
+    out = tmp_path / "export.json"
+    ok, _ = mod.export_settings(rows, str(out))
+    assert ok
+    data = json.loads(out.read_text())
+    assert "DnsMode" not in data
+    assert "DnsTemplates" not in data
+
+
+def test_import_legacy_array_first_match_wins(mod, tmp_path):
+    cfg = tmp_path / "legacy.json"
+    cfg.write_text(json.dumps(
+        {"Features": ["IncognitoModeAvailability", "BraveRewardsDisabled"]}
+    ))
+    rows = mod.build_rows()
+    ok, _ = mod.import_settings(rows, str(cfg))
+    assert ok
+    # First row for the key wins (Disable, value 1); Force stays unchecked.
+    assert _get_feature(mod, rows, "Disable Incognito Mode")["checked"] is True
+    assert _get_feature(mod, rows, "Force Incognito Mode")["checked"] is False
+    assert _get_feature(mod, rows, "Disable Brave Rewards")["checked"] is True
+
+
+def test_parse_imported_features_formats(mod):
+    assert mod._parse_imported_features({"A": 1}) == ({"A": 1}, False)
+    assert mod._parse_imported_features(["A", "B"]) == ({"A": None, "B": None}, True)
+    assert mod._parse_imported_features("garbage") == ({}, False)
+    assert mod._parse_imported_features(None) == ({}, False)
+
+
+# ---------------------------------------------------------------------------
+# BOM-aware JSON reader (PowerShell export compatibility)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("encoding,bom", [
+    ("utf-8", b""),
+    ("utf-8", b"\xef\xbb\xbf"),
+    ("utf-16-le", b"\xff\xfe"),
+    ("utf-16-be", b"\xfe\xff"),
+])
+def test_read_json_file_handles_boms(mod, tmp_path, encoding, bom):
+    payload = {"Features": {"BraveRewardsDisabled": True}}
+    path = tmp_path / f"{encoding}.json"
+    path.write_bytes(bom + json.dumps(payload).encode(encoding))
+    assert mod.read_json_file(str(path)) == payload
+
+
+# ---------------------------------------------------------------------------
+# --policy-file path validation
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_policy_dir_accepts_inside_path(mod, tmp_path, monkeypatch):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    monkeypatch.setattr(mod, "ALLOWED_POLICY_DIRS", (str(allowed),))
+    assert mod._is_within_allowed_policy_dir(str(allowed / "policy.json"))
+
+
+def test_allowed_policy_dir_rejects_outside_path(mod, tmp_path, monkeypatch):
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    monkeypatch.setattr(mod, "ALLOWED_POLICY_DIRS", (str(allowed),))
+    assert not mod._is_within_allowed_policy_dir(str(tmp_path / "shadow"))
+    assert not mod._is_within_allowed_policy_dir(
+        str(allowed / ".." / "shadow"))
+    # The allowed dir itself is not a writable target, only paths inside it
+    assert not mod._is_within_allowed_policy_dir(str(allowed))
+
+
+def test_allowed_policy_dir_rejects_symlink_escape(mod, tmp_path, monkeypatch):
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    (allowed / "link").symlink_to(outside)
+    monkeypatch.setattr(mod, "ALLOWED_POLICY_DIRS", (str(allowed),))
+    assert not mod._is_within_allowed_policy_dir(
+        str(allowed / "link" / "policy.json"))
+
+
+# ---------------------------------------------------------------------------
+# Target dedupe + policy sync
+# ---------------------------------------------------------------------------
+
+
+def test_dedupe_plist_targets(mod):
+    shared = [
+        {"plist_path": "/etc/x.json", "label": "Stable"},
+        {"plist_path": "/etc/x.json", "label": "Beta"},
+    ]
+    assert mod._dedupe_plist_targets(shared) == [("/etc/x.json", "Stable, Beta")]
+    split = [
+        {"plist_path": "/etc/a.plist", "label": "Stable"},
+        {"plist_path": "/etc/b.plist", "label": "Beta"},
+    ]
+    assert mod._dedupe_plist_targets(split) == [
+        ("/etc/a.plist", "Stable"), ("/etc/b.plist", "Beta"),
+    ]
+
+
+def test_sync_rows_with_policy_checks_matching_rows(mod):
+    rows = mod.build_rows()
+    mod.sync_rows_with_policy(rows, {
+        "BraveRewardsDisabled": True,
+        "IncognitoModeAvailability": 2,
+    })
+    assert _get_feature(mod, rows, "Disable Brave Rewards")["checked"] is True
+    assert _get_feature(mod, rows, "Force Incognito Mode")["checked"] is True
+    assert _get_feature(mod, rows, "Disable Incognito Mode")["checked"] is False
+
+
+def test_sync_rows_shows_secure_plus_template_as_custom(mod):
+    rows = mod.build_rows()
+    mod.sync_rows_with_policy(rows, {
+        "DnsOverHttpsMode": "secure",
+        "DnsOverHttpsTemplates": "https://dns.example/dns-query",
+    })
+    assert mod.get_dns_mode(rows) == "custom"
+    assert mod.get_dns_template(rows) == "https://dns.example/dns-query"
+
+
+# ---------------------------------------------------------------------------
+# Prefs-leak repair
+# ---------------------------------------------------------------------------
+
+
+def test_repair_one_prefs_scrubs_only_slimbrave_patterns(mod, tmp_path, monkeypatch):
+    monkeypatch.delenv("SUDO_USER", raising=False)
+    prefs = {
+        "bookmarks": {"kept": True},
+        "profile": {"content_settings": {"exceptions": {"braveShields": {
+            "http://*,*": {"setting": 2},
+            "https://*,*": {"setting": 2},
+            "https://example.com,*": {"setting": 2},  # user's own override
+        }}}},
+    }
+    path = tmp_path / "Preferences"
+    path.write_text(json.dumps(prefs))
+
+    assert mod._repair_one_prefs(str(path)) == 2
+
+    after = json.loads(path.read_text())
+    shields = after["profile"]["content_settings"]["exceptions"]["braveShields"]
+    assert list(shields) == ["https://example.com,*"]
+    assert after["bookmarks"] == {"kept": True}
+    # Idempotent: nothing left to remove on a second pass
+    assert mod._repair_one_prefs(str(path)) == 0
+
+
+def test_repair_one_prefs_ignores_missing_or_invalid(mod, tmp_path):
+    assert mod._repair_one_prefs(str(tmp_path / "nope")) == 0
+    bad = tmp_path / "Preferences"
+    bad.write_text("{not json")
+    assert mod._repair_one_prefs(str(bad)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Presets stay in sync with the feature definitions
+# ---------------------------------------------------------------------------
+
+
+def _feature_pairs(mod):
+    pairs = {}
+    for cat in mod.CATEGORIES:
+        for feat in cat["features"]:
+            pairs.setdefault(feat["key"], []).append(feat["value"])
+    return pairs
+
+
+# Keys presets may contain that are deliberately absent on some platforms;
+# the import silently skips them there. BackgroundModeEnabled has no macOS
+# support in Chromium (see AUDIT.md), so the mac script doesn't expose it.
+PLATFORM_OMITTED_KEYS = {"BackgroundModeEnabled"}
+
+
+@pytest.mark.parametrize(
+    "preset", sorted((ROOT / "Presets").glob("*.json")),
+    ids=lambda p: p.stem,
+)
+def test_presets_match_feature_definitions(mod, preset):
+    config = json.loads(preset.read_text())
+    known = _feature_pairs(mod)
+    for key, value in config["Features"].items():
+        if key in PLATFORM_OMITTED_KEYS and key not in known:
+            continue
+        assert key in known, f"{preset.name}: unknown policy key {key}"
+        assert value in known[key], (
+            f"{preset.name}: {key}={value!r} matches no feature row "
+            f"(expected one of {known[key]!r}) — the import would silently skip it"
+        )
+    dns_mode = config.get("DnsMode")
+    if dns_mode is not None:
+        assert dns_mode in mod.DNS_MODES
+    if "DnsTemplates" in config:
+        assert dns_mode in ("custom", "secure")


### PR DESCRIPTION
Full-repo audit pass now that the project is feature complete. Overall the codebase came out clean — atomic writes, path validation, prefs-leak repair, and the June 2026 policy audit all check out. This PR fixes the small parity gaps the audit found, tunes three presets, and adds a test suite + CI. Per the project's design, `slimbrave-linux.py` and `slimbrave-mac.py` stay separate; shared fixes are mirrored into each file independently.

## Bug / parity fixes

- **Windows: prefs repair covered only Stable.** `Repair-BravePrefs` hardcoded `Brave-Browser\User Data`; it now scrubs Beta/Nightly/Dev profiles too, matching the Python scripts (the registry policy applies to every channel).
- **Windows: `DnsMode=secure` dropped its template.** A cross-platform config with `secure` + `DnsTemplates` lost its resolver on Windows; the template is now kept for `secure`, and the template box enables for it.
- **Linux/macOS: Flatpak profiles were never repaired.** Flatpak Brave keeps its profile under `~/.var/app/com.brave.Browser/config`, invisible to the native channel paths. Detection and prefs repair now cover it. (Verified against the Flathub manifest: it grants `--filesystem=host-etc` specifically to read `/etc/brave/policies`, so the shared policy file already worked — no Snap-style warning needed.)
- **CLI exit codes accumulate** so a failed `--reset` can't be masked by a subsequent successful `--import`.
- **macOS:** reset/mode-switch also removes the staged `/tmp/slimbrave-neo-policy.mobileconfig`.
- **Export under sudo** chowns the file back to the invoking user instead of stranding a root-owned file in their home.
- **Dead code:** removed the unused `ROW_CHANNEL` handling in the Linux TUI and the vestigial `rows` arg on `_selected_channel_targets`; fixed the dead `except KeyError` around `expanduser` (it never raises — unknown users are detected by the unexpanded result).
- **Windows polish:** the HKLM policy key is created at Apply time instead of at launch (opening the app no longer writes to the registry), and the DNS dropdown order matches the Python TUIs.

## Preset tuning

- **Balanced + Maximum Privacy:** dropped `ForceGoogleSafeSearch` — it's a content filter, not a privacy measure; it remains in Strict Parental Controls.
- **Maximum Privacy:** DNS is now left unmanaged instead of force-disabling DoH. Plain DNS hands every query to the ISP in cleartext, which is arguably worse for this preset's threat model than DoH-provider logging; the README now explains the trade-off and leaves the choice to the user.
- **Performance Focused:** now also disables P3A and the daily stats ping (zero perf cost), matching its README description.

## Tests + CI

- `tests/test_slimbrave.py`: 56 tests running against **both** Python scripts (policy building, import/export round-trips including multi-value keys, BOM-aware JSON reading, `--policy-file` path validation incl. symlink escape, prefs-leak repair, group exclusivity, and a preset↔feature-definition consistency check that guards against key drift).
- `.github/workflows/ci.yml`: pytest + ruff on ubuntu, PSScriptAnalyzer for `SlimBrave.ps1` (fails on errors, reports warnings).
- User-facing scripts remain stdlib-only; pytest/ruff are CI-only.

## Verification

- `pytest -q`: 56 passed; `ruff check .`: clean.
- Smoke-tested non-root CLI paths: `--policy-file /etc/shadow --reset` rejected with exit 2; all five presets import and build valid policy dicts end-to-end (Max Privacy now 45 keys/DNS unmanaged, Strict Parental resolves `custom` → `secure` + family DoH template).
- PowerShell changes are minimal and mirrored from the tested Python logic; PSScriptAnalyzer runs in CI (no Windows host locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)